### PR TITLE
GetOwnProfile is fixed, many other changes

### DIFF
--- a/LichessNET/API/APIRatelimitController.cs
+++ b/LichessNET/API/APIRatelimitController.cs
@@ -53,31 +53,31 @@ public class ApiRatelimitController
         _buckets.Add(endpointUrl, bucket);
     }
 
-    public void Consume()
+    public async Task Consume()
     {
         PipedRequests++;
         if (_rateLimitedUntil > DateTime.Now)
         {
             _logger.LogWarning("Endpoint blocked due to ratelimit. Waiting for " +
                                (_rateLimitedUntil - DateTime.Now).Milliseconds + " ms.");
-            Thread.Sleep((_rateLimitedUntil - DateTime.Now).Milliseconds);
+            await Task.Delay((_rateLimitedUntil - DateTime.Now).Milliseconds);
         }
 
         _defaultBucket.Consume();
         PipedRequests--;
     }
 
-    public void Consume(string endpointUrl, bool consumedefaultBucket)
+    public async Task Consume(string endpointUrl, bool consumeDefaultBucket)
     {
         PipedRequests++;
         if (_rateLimitedUntil > DateTime.Now)
         {
             _logger.LogWarning("Endpoint call to " + endpointUrl + " blocked due to ratelimit. Waiting for " +
                                (_rateLimitedUntil - DateTime.Now).Milliseconds + " ms.");
-            Thread.Sleep((_rateLimitedUntil - DateTime.Now).Milliseconds);
+            await Task.Delay((_rateLimitedUntil - DateTime.Now).Milliseconds);
         }
 
-        if (consumedefaultBucket) _defaultBucket.Consume();
+        if (consumeDefaultBucket) _defaultBucket.Consume();
         if (_buckets.TryGetValue(endpointUrl, out var bucket)) bucket.Consume();
 
         PipedRequests--;

--- a/LichessNET/API/AccountAPI.cs
+++ b/LichessNET/API/AccountAPI.cs
@@ -40,8 +40,7 @@ public partial class LichessApiClient
 
         var request = GetRequestScaffold("api/account");
         var response = await SendRequest(request);
-        var content = await response.Content.ReadAsStringAsync();
-        return JsonConvert.DeserializeObject<LichessUser>(content);
+        return await response.Content.ReadFromJsonAsync<LichessUser>();
     }
 
     /// <summary>

--- a/LichessNET/API/AccountAPI.cs
+++ b/LichessNET/API/AccountAPI.cs
@@ -93,8 +93,6 @@ public partial class LichessApiClient
     /// </returns>
     public async Task<bool> SetKidModeStatus(bool enable)
     {
-        _ratelimitController.Consume("api/account", false);
-
         var request = GetRequestScaffold("api/account/kid", Tuple.Create("v", enable.ToString()));
         var response = await SendRequest(request, HttpMethod.Post);
 

--- a/LichessNET/API/AccountAPI.cs
+++ b/LichessNET/API/AccountAPI.cs
@@ -22,10 +22,8 @@ public partial class LichessApiClient
         var request = GetRequestScaffold("api/account/email");
 
         var response = await SendRequest(request);
-        var content = await response.Content.ReadAsStringAsync();
-
-        var emailResponse = JsonConvert.DeserializeObject<dynamic>(content);
-        return emailResponse.email.ToObject<string>();
+        var content = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+        return content["email"];
     }
 
     /// <summary>

--- a/LichessNET/API/AccountAPI.cs
+++ b/LichessNET/API/AccountAPI.cs
@@ -109,7 +109,8 @@ public partial class LichessApiClient
 
         var request = GetRequestScaffold($"api/rel/follow/{username}");
         var response = await SendRequest(request, HttpMethod.Post);
-        return JsonConvert.DeserializeObject<dynamic>(await response.Content.ReadAsStringAsync()).ok.ToObject<bool>();
+        var content = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>();
+        return content["ok"];
     }
 
     /// <summary>
@@ -127,7 +128,8 @@ public partial class LichessApiClient
 
         var request = GetRequestScaffold($"api/rel/unfollow/{username}");
         var response = await SendRequest(request, HttpMethod.Post);
-        return JsonConvert.DeserializeObject<dynamic>(await response.Content.ReadAsStringAsync()).ok.ToObject<bool>();
+        var content = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>();
+        return content["ok"];
     }
 
     /// <summary>
@@ -145,7 +147,8 @@ public partial class LichessApiClient
 
         var request = GetRequestScaffold($"api/rel/block/{username}");
         var response = await SendRequest(request, HttpMethod.Post);
-        return JsonConvert.DeserializeObject<dynamic>(await response.Content.ReadAsStringAsync()).ok.ToObject<bool>();
+        var content = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>();
+        return content["ok"];
     }
 
     /// <summary>
@@ -163,7 +166,8 @@ public partial class LichessApiClient
 
         var request = GetRequestScaffold($"api/rel/unblock/{username}");
         var response = await SendRequest(request, HttpMethod.Post);
-        return JsonConvert.DeserializeObject<dynamic>(await response.Content.ReadAsStringAsync())!.ok.ToObject<bool>();
+        var content = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>();
+        return content["ok"];
     }
 
     /// <summary>

--- a/LichessNET/API/AccountAPI.cs
+++ b/LichessNET/API/AccountAPI.cs
@@ -54,10 +54,9 @@ public partial class LichessApiClient
         var request = GetRequestScaffold("api/account/preferences");
 
         var response = await SendRequest(request);
-        var content = await response.Content.ReadAsStringAsync();
 
 
-        var preferences = JsonConvert.DeserializeObject<AccountPreferences>(content);
+        var preferences = await response.Content.ReadFromJsonAsync<AccountPreferences>();
         return preferences;
     }
 

--- a/LichessNET/API/AccountAPI.cs
+++ b/LichessNET/API/AccountAPI.cs
@@ -1,4 +1,5 @@
-﻿using LichessNET.Entities;
+﻿using System.Net.Http.Json;
+using LichessNET.Entities;
 using LichessNET.Entities.Account;
 using LichessNET.Entities.Social;
 using LichessNET.Entities.Social.Timeline;
@@ -76,10 +77,8 @@ public partial class LichessApiClient
         var request = GetRequestScaffold("api/account/kid");
 
         var response = await SendRequest(request);
-        var content = await response.Content.ReadAsStringAsync();
-
-        var kidModeStatus = JsonConvert.DeserializeObject<dynamic>(content).kid.ToObject<bool>();
-        return kidModeStatus;
+        var content = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>();
+        return content["kid"];
     }
 
     /// <summary>

--- a/LichessNET/API/LichessAPIClient.cs
+++ b/LichessNET/API/LichessAPIClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Web;
+using LichessNET.Entities.OAuth;
 using Microsoft.Extensions.Logging;
 using TokenBucket;
 using Vertical.SpectreLogger;
@@ -31,13 +32,34 @@ public partial class LichessApiClient
     /// <summary>
     ///     The token to access the Lichess API
     /// </summary>
-    internal string Token = "";
+    private string? _token;
+
+    public string? GetToken() => _token;
+
+    public async Task SetToken(string? value)
+    {
+        if (value == null)
+        {
+            _token = null;
+            return;
+        }
+        var tokenTest = await TestTokensAsync(new List<string> { value });
+        if (tokenTest[value] is not null)
+        {
+            _token = value;
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.GetToken());
+        }
+        else
+        {
+            throw new UnauthorizedAccessException("Invalid token");
+        }
+    }
 
     /// <summary>
     ///     Creates a lichess API client, according to settings
     /// </summary>
     /// <param name="token">The token for accessing the lichess API</param>
-    public LichessApiClient(string token = "")
+    public LichessApiClient()
     {
         var loggerFactory = LoggerFactory.Create(builder => builder
             .SetMinimumLevel(Constants.MinimumLogLevel)
@@ -45,20 +67,8 @@ public partial class LichessApiClient
 
         _logger = loggerFactory.CreateLogger("LichessAPIClient");
 
-
-        this.Token = token;
-        _httpClient = new HttpClient();
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.Token);
         
-        if (token != "")
-            _logger.LogInformation("Connecting to Lichess API with token");
-        else
-            _logger.LogInformation("Connecting to Lichess API without token");
-
-        if (!token.Contains("_"))
-            _logger.LogWarning("The token provided may not be a valid lichess API token. Please check the token.");
-
-        _logger.LogInformation("Connection to Lichess API established.");
+        _httpClient = new HttpClient();
 
         _ratelimitController.RegisterBucket("api/account", TokenBuckets.Construct().WithCapacity(5)
             .WithFixedIntervalRefillStrategy(3, TimeSpan.FromSeconds(15)).Build());
@@ -123,16 +133,12 @@ public partial class LichessApiClient
 
         if (response.StatusCode == HttpStatusCode.Forbidden)
         {
-            if ((await response.Content.ReadAsStringAsync()).Contains("Missing scope"))
-            {
-                _logger.LogError(
-                    "The token provided does not have the required scope to access this endpoint. The client will " +
-                    "resend a request without a token.");
-                return await SendRequest(new HttpRequestMessage()
-                {
-                    RequestUri = request.RequestUri
-                }, method, false);
-            }
+            throw new HttpRequestException("Access denied. Your token does not have the required scope.");
+        }
+        
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            throw new UnauthorizedAccessException("Api Key is invalid.");
         }
 
         _logger.LogError("Error while fetching data from Lichess API. Status code: " + response.StatusCode);

--- a/LichessNET/API/LichessAPIClient.cs
+++ b/LichessNET/API/LichessAPIClient.cs
@@ -106,7 +106,7 @@ public partial class LichessApiClient
         request.Content = content;
         
         _logger.LogInformation("Sending request to " + request.RequestUri);
-        var response = client.SendAsync(request).Result;
+        var response = await client.SendAsync(request);
         if (response.IsSuccessStatusCode)
         {
             _logger.LogInformation("Request to " + request.RequestUri + " successful.");

--- a/LichessNET/API/OAuthAPI.cs
+++ b/LichessNET/API/OAuthAPI.cs
@@ -24,6 +24,6 @@ public partial class LichessApiClient
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var request = GetRequestScaffold("api/token");
         var response = await SendRequest(request, method: HttpMethod.Delete);
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetToken());
     }
 }

--- a/LichessNET/API/OAuthAPI.cs
+++ b/LichessNET/API/OAuthAPI.cs
@@ -1,0 +1,29 @@
+﻿using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LichessNET.Entities.Enumerations;
+using LichessNET.Entities.OAuth;
+
+namespace LichessNET.API;
+
+public partial class LichessApiClient
+{
+    public async Task<Dictionary<string, TokenInfo?>> TestTokensAsync(List<string> tokens)
+    {
+        var tokenBody = string.Join(',', tokens);
+        var request = GetRequestScaffold("api/token/test");
+        var response = await SendRequest(request, content: new StringContent(tokenBody), method: HttpMethod.Post);
+        Console.WriteLine(await response.Content.ReadAsStringAsync());
+        var tokenInfo = await response.Content.ReadFromJsonAsync<Dictionary<string, TokenInfo>>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true});
+        return tokenInfo;
+    }
+
+    public async Task DeleteTokenAsync(string token)
+    {
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var request = GetRequestScaffold("api/token");
+        var response = await SendRequest(request, method: HttpMethod.Delete);
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+    }
+}

--- a/LichessNET/API/UsersAPI.cs
+++ b/LichessNET/API/UsersAPI.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Json;
+using System.Text.Json;
 using LichessNET.Entities.Account.Performance;
 using LichessNET.Entities.Enumerations;
 using LichessNET.Entities.Social;
@@ -53,10 +54,9 @@ public partial class LichessApiClient
         );
 
         var response = await SendRequest(request);
-        var content = await response.Content.ReadAsStringAsync();
-
-        var userStatuses = JsonConvert.DeserializeObject<List<UserRealTimeStatus>>(content);
-        return userStatuses;
+        var content = await response.Content.ReadFromJsonAsync<List<UserRealTimeStatus>>(new JsonSerializerOptions()
+            { PropertyNameCaseInsensitive = true });
+        return content;
     }
 
     /// <summary>

--- a/LichessNET/Converters/GameStatsConverter.cs
+++ b/LichessNET/Converters/GameStatsConverter.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using LichessNET.Entities.Enumerations;
+using LichessNET.Entities.Game;
+using LichessNET.Entities.Interfaces;
+using LichessNET.Entities.Stats;
+
+namespace LichessNET.Converters;
+
+public class GameStatsConverter : JsonConverter<Dictionary<Gamemode, IGameStats>>
+{
+    public override Dictionary<Gamemode, IGameStats>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var output = new Dictionary<Gamemode, IGameStats>();
+        using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
+        {
+            foreach (JsonProperty property in doc.RootElement.EnumerateObject())
+            {
+                Console.WriteLine(property.Name);
+                if (Gamemode.TryParse(property.Name, true, out Gamemode gamemode))
+                {
+                    IGameStats? stats = null;
+                    if (property.Value.TryGetProperty("games", out _))
+                    {
+                        stats = JsonSerializer.Deserialize<GamemodeStats>(property.Value, new JsonSerializerOptions(){PropertyNameCaseInsensitive = true});
+                    }
+                    else if (property.Value.TryGetProperty("runs", out _))
+                    {
+                        stats = JsonSerializer.Deserialize<RunStats>(property.Value, new JsonSerializerOptions(){PropertyNameCaseInsensitive = true});
+                    }
+
+                    if (stats != null)
+                    {
+                        output.Add(gamemode, stats);
+                    }
+                }
+            }
+            
+        }
+
+        return output;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Dictionary<Gamemode, IGameStats> value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/LichessNET/Converters/MillisecondUnixConverter.cs
+++ b/LichessNET/Converters/MillisecondUnixConverter.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LichessNET.Converters;
+
+public class MillisecondUnixConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var milliseconds = reader.GetInt64();
+        DateTime unixEpoch = DateTime.UnixEpoch;
+        return unixEpoch.Add(TimeSpan.FromMilliseconds(milliseconds));
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/LichessNET/Converters/PermissionJsonConverter.cs
+++ b/LichessNET/Converters/PermissionJsonConverter.cs
@@ -1,21 +1,15 @@
-﻿using System.Text.Json.Serialization;
-using LichessNET.Converters;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using LichessNET.Entities.Enumerations;
 
-namespace LichessNET.Entities.OAuth;
+namespace LichessNET.Converters;
 
-public class TokenInfo
+public class PermissionJsonConverter : JsonConverter<List<TokenPermission>>
 {
-    public string UserId { get; set; }
-    
-    [JsonConverter(typeof(PermissionJsonConverter))]
-    [JsonPropertyName("scopes")]
-    public List<TokenPermission> Permissions { get; set; }
-    public int? Expires { get; set; }
-
-    public bool IsAllowed(TokenPermission permission) => Permissions.Contains(permission);
-    public static List<TokenPermission> GetPermissions(string permissions)
+    public override List<TokenPermission>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+
+        var permissions = reader.GetString();
         string[] permissionsList = permissions.Split(',');
         List<TokenPermission> tokenPermissions = new List<TokenPermission>();
 
@@ -87,5 +81,10 @@ public class TokenInfo
         }
 
         return tokenPermissions;
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<TokenPermission> value, JsonSerializerOptions options)
+    {
+        
     }
 }

--- a/LichessNET/Converters/PermissionJsonConverter.cs
+++ b/LichessNET/Converters/PermissionJsonConverter.cs
@@ -85,6 +85,6 @@ public class PermissionJsonConverter : JsonConverter<List<TokenPermission>>
 
     public override void Write(Utf8JsonWriter writer, List<TokenPermission> value, JsonSerializerOptions options)
     {
-        
+        throw new NotImplementedException();
     }
 }

--- a/LichessNET/Converters/SecondsToTimeSpanConverter.cs
+++ b/LichessNET/Converters/SecondsToTimeSpanConverter.cs
@@ -1,0 +1,38 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using LichessNET.Entities.Stats;
+
+namespace LichessNET.Converters;
+
+public class SecondsToTimeSpanConverter : JsonConverter<Playtime>
+{
+    public override Playtime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        Playtime playtime = new Playtime();
+        playtime.TotalSpan = TimeSpan.Zero;
+        playtime.TvSpan = TimeSpan.Zero;
+        
+        using (var doc = JsonDocument.ParseValue(ref reader))
+        {
+            var stats = doc.RootElement.EnumerateObject();
+            foreach (JsonProperty property in stats)
+            {
+                if (property.Name == "total")
+                {
+                    playtime.TotalSpan = TimeSpan.FromSeconds(property.Value.GetInt64());
+                }
+                else if (property.Name == "tv")
+                {
+                    playtime.TvSpan = TimeSpan.FromSeconds(property.Value.GetInt64());
+                }
+            }
+        }
+        
+        return playtime;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Playtime value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/LichessNET/Entities/Enumerations/GameStatus.cs
+++ b/LichessNET/Entities/Enumerations/GameStatus.cs
@@ -1,0 +1,18 @@
+﻿namespace LichessNET.Entities.Enumerations;
+
+public enum GameStatus
+{
+    Created,
+    Started,
+    Aborted,
+    Mate,
+    Resign,
+    Stalemate,
+    Timeout,
+    Draw,
+    OutOfTime,
+    Cheat,
+    NoStart,
+    UnknownFinish,
+    VariantEnd,
+}

--- a/LichessNET/Entities/Enumerations/Gamemode.cs
+++ b/LichessNET/Entities/Enumerations/Gamemode.cs
@@ -21,7 +21,10 @@ public enum Gamemode
     [EnumMember(Value = "horde")] Horde,
     [EnumMember(Value = "racingKings")] RacingKings,
     [EnumMember(Value = "crazyhouse")] Crazyhouse,
-    [EnumMember(Value = "puzzle")] Storm,
-    [EnumMember(Value = "puzzle")] Racer,
-    [EnumMember(Value = "puzzle")] Streak
+    Storm, 
+    Racer,
+    Streak,
+    UltraBullet,
+    Correspondence,
+    Puzzle
 }

--- a/LichessNET/Entities/Enumerations/Speed.cs
+++ b/LichessNET/Entities/Enumerations/Speed.cs
@@ -1,0 +1,11 @@
+﻿namespace LichessNET.Entities.Enumerations;
+
+public enum Speed
+{
+    UltraBullet, 
+    Bullet,
+    Blitz,
+    Rapid,
+    Classical,
+    Correspondence,
+}

--- a/LichessNET/Entities/Enumerations/Title.cs
+++ b/LichessNET/Entities/Enumerations/Title.cs
@@ -16,6 +16,5 @@ public enum Title
     WFM,
     WIM,
     WGM,
-
-    None
+    Bot,
 }

--- a/LichessNET/Entities/Enumerations/TokenPermission.cs
+++ b/LichessNET/Entities/Enumerations/TokenPermission.cs
@@ -1,0 +1,25 @@
+﻿namespace LichessNET.Entities.Enumerations;
+
+public enum TokenPermission
+{
+    ReadEmail,
+    ReadPreferences,
+    WritePreferences,
+    ReadFollows,
+    WriteFollows,
+    WriteMessages,
+    ReadChallenges,
+    WriteChallenges,
+    BulkChallenges,
+    WriteTournaments,
+    ReadTeams,
+    WriteTeams,
+    ManageTeams,
+    ReadPuzzleActivity,
+    WriteRaces,
+    ReadStudies,
+    WriteStudies,
+    PlayGames,
+    ReadEngines,
+    ManageEngines,
+}

--- a/LichessNET/Entities/Game/GamePlayer.cs
+++ b/LichessNET/Entities/Game/GamePlayer.cs
@@ -11,6 +11,6 @@ public class GamePlayer
     public string Name { get; set; }
 
     //TODO: Add serialization for Title
-    public Title Title { get; set; } = Title.None;
+    public Title? Title { get; set; }
     public int Rating { get; set; }
 }

--- a/LichessNET/Entities/Interfaces/IGameStats.cs
+++ b/LichessNET/Entities/Interfaces/IGameStats.cs
@@ -1,0 +1,6 @@
+﻿namespace LichessNET.Entities.Interfaces;
+
+public interface IGameStats
+{
+    
+}

--- a/LichessNET/Entities/OAuth/TokenInfo.cs
+++ b/LichessNET/Entities/OAuth/TokenInfo.cs
@@ -1,0 +1,100 @@
+﻿using System.Text.Json.Serialization;
+using LichessNET.Entities.Enumerations;
+
+namespace LichessNET.Entities.OAuth;
+
+public class TokenInfo
+{
+    [JsonInclude]
+    private string scopes { get; set; }
+    public string UserId { get; set; }
+    public List<TokenPermission> Permissions { get; set; }
+    public int? Expires { get; set; }
+    
+    [JsonConstructor]
+    public TokenInfo(string userId, string scopes, int? expires)
+    {
+        UserId = userId;
+        Expires = expires;
+        Permissions = TokenInfo.GetPermissions(scopes);
+    }
+
+    public bool IsAllowed(TokenPermission permission) => Permissions.Contains(permission);
+    public static List<TokenPermission> GetPermissions(string permissions)
+    {
+        string[] permissionsList = permissions.Split(',');
+        List<TokenPermission> tokenPermissions = new List<TokenPermission>();
+
+        foreach (string permission in permissionsList)
+        {
+            switch (permission)
+            {
+                case "email:read":
+                    tokenPermissions.Add(TokenPermission.ReadEmail);
+                    break;
+                case "preference:read":
+                    tokenPermissions.Add(TokenPermission.ReadPreferences);
+                    break;
+                case "preference:write":
+                    tokenPermissions.Add(TokenPermission.WritePreferences);
+                    break;
+                case "follow:read":
+                    tokenPermissions.Add(TokenPermission.ReadFollows);
+                    break;
+                case "follow:write":
+                    tokenPermissions.Add(TokenPermission.WriteFollows);
+                    break;
+                case "msg:write":
+                    tokenPermissions.Add(TokenPermission.WriteMessages);
+                    break;
+                case "challenge:read":
+                    tokenPermissions.Add(TokenPermission.ReadChallenges);
+                    break;
+                case "challenge:write":
+                    tokenPermissions.Add(TokenPermission.WriteChallenges);
+                    break;
+                case "challenge:bulk":
+                    tokenPermissions.Add(TokenPermission.BulkChallenges);
+                    break;
+                case "tournament:write":
+                    tokenPermissions.Add(TokenPermission.WriteTournaments);
+                    break;
+                case "team:read":
+                    tokenPermissions.Add(TokenPermission.ReadTeams);
+                    break;
+                case "team:write":
+                    tokenPermissions.Add(TokenPermission.WriteTeams);
+                    break;
+                case "team:lead":
+                    tokenPermissions.Add(TokenPermission.ManageTeams);
+                    break;
+                case "puzzle:read":
+                    tokenPermissions.Add(TokenPermission.ReadPuzzleActivity);
+                    break;
+                case "racer:write":
+                    tokenPermissions.Add(TokenPermission.WriteRaces);
+                    break;
+                case "study:read":
+                    tokenPermissions.Add(TokenPermission.ReadStudies);
+                    break;
+                case "study:write":
+                    tokenPermissions.Add(TokenPermission.WriteStudies);
+                    break;
+                case "board:play":
+                    tokenPermissions.Add(TokenPermission.PlayGames);
+                    break;
+                case "engine:read":
+                    tokenPermissions.Add(TokenPermission.ReadEngines);
+                    break;
+                case "engine:write":
+                    tokenPermissions.Add(TokenPermission.ManageEngines);
+                    break;
+                default:
+                    // Если не удалось сопоставить разрешение, можно вывести ошибку или просто игнорировать
+                    break;
+            }
+        }
+
+        return tokenPermissions;
+    }
+}

--- a/LichessNET/Entities/Social/LichessProfile.cs
+++ b/LichessNET/Entities/Social/LichessProfile.cs
@@ -8,51 +8,51 @@ public class LichessProfile
     /// <summary>
     ///     The current country flag of the user
     /// </summary>
-    public string Flag { get; set; }
+    public string? Flag { get; set; }
 
     /// <summary>
     ///     The set location of this user
     /// </summary>
-    public string Location { get; set; }
+    public string? Location { get; set; }
 
     /// <summary>
     ///     The bio of the user
     /// </summary>
-    public string Bio { get; set; }
+    public string? Bio { get; set; }
 
     /// <summary>
     ///     The set real name of the user
     /// </summary>
-    public string RealName { get; set; }
+    public string? RealName { get; set; }
 
     /// <summary>
     ///     FIDE rating of the user
     /// </summary>
-    public ushort FideRating { get; set; }
+    public ushort? FideRating { get; set; }
 
     /// <summary>
     ///     USCF rating of the user
     /// </summary>
-    public ushort UsCfRating { get; set; }
+    public ushort? UsCfRating { get; set; }
 
     /// <summary>
     ///     ECF rating of the user
     /// </summary>
-    public ushort EcfRating { get; set; }
+    public ushort? EcfRating { get; set; }
 
     /// <summary>
     ///     CFC rating of the user
     /// </summary>
-    public ushort CfcRating { get; set; }
+    public ushort? CfcRating { get; set; }
 
     /// <summary>
     ///     DSB rating of the user
     /// </summary>
-    public ushort DsbRating { get; set; }
+    public ushort? DsbRating { get; set; }
 
     /// <summary>
     ///     Links mentioned in the bio of the user
     ///     Each link is seperated by \r\n
     /// </summary>
-    public string Links { get; set; }
+    public string? Links { get; set; }
 }

--- a/LichessNET/Entities/Social/LichessUser.cs
+++ b/LichessNET/Entities/Social/LichessUser.cs
@@ -1,4 +1,7 @@
-﻿using LichessNET.Entities.Enumerations;
+﻿using System.Text.Json.Serialization;
+using LichessNET.Converters;
+using LichessNET.Entities.Enumerations;
+using LichessNET.Entities.Interfaces;
 using LichessNET.Entities.Stats;
 using Newtonsoft.Json.Linq;
 
@@ -25,14 +28,17 @@ public class LichessUser
     ///     If the data is fetched in the request, the ratings will be set here.
     ///     The dictionary only contains those gamemodes as key, which were fetched.
     /// </summary>
-    public Dictionary<Gamemode, GamemodeStats>? Ratings { get; set; }
+    [JsonPropertyName("perfs")]
+    [JsonConverter(typeof(GameStatsConverter))]
+    public Dictionary<Gamemode, IGameStats>? Ratings { get; set; }
 
     /// <summary>
     ///     Current flair of the user
     /// </summary>
     public string? Flair { get; set; }
-
-    private ulong? CreatedAt { get; set; }
+    
+    [JsonConverter(typeof(MillisecondUnixConverter))]
+    public DateTime? CreatedAt { get; set; }
 
     /// <summary>
     ///     Will be set to true if the user profile is disabled
@@ -42,19 +48,20 @@ public class LichessUser
     /// <summary>
     ///     Will be set to true if the account is flagged for TOS violations
     /// </summary>
-    public bool? TosViolation { get; set; }
+    public bool TosViolation { get; set; }
 
     /// <summary>
     ///     The LichessProfile of the user
     /// </summary>
     public LichessProfile? Profile { get; set; }
 
-    private ulong? SeenAt { get; set; }
+    [JsonConverter(typeof(MillisecondUnixConverter))]
+    public DateTime? SeenAt { get; set; }
 
     /// <summary>
     ///     If set to true, this user is an active patron of lichess
     /// </summary>
-    public bool? Patron { get; set; }
+    public bool Patron { get; set; }
 
     /// <summary>
     ///     Set to true if the user is a verfied user
@@ -69,43 +76,8 @@ public class LichessUser
     /// <summary>
     ///     Title of this user as string
     /// </summary>
-    internal string? title { get; set; }
-
-    /// <summary>
-    ///     The Title as an enumeration.
-    ///     If the user has no title, Title.None will be returned
-    /// </summary>
-    public Title Title
-    {
-        get
-        {
-            switch (title)
-            {
-                case "CM":
-                    return Title.CM;
-                case "FM":
-                    return Title.FM;
-                case "IM":
-                    return Title.IM;
-                case "GM":
-                    return Title.GM;
-
-                case "WCM":
-                    return Title.WCM;
-                case "WFM":
-                    return Title.WFM;
-                case "WIM":
-                    return Title.WIM;
-                case "WGM":
-                    return Title.WGM;
-
-                case "LM":
-                    return Title.LM;
-                default:
-                    return Title.None;
-            }
-        }
-    }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public Title? Title { get; set; }
 
     /// <summary>
     ///     The game count stats
@@ -118,11 +90,15 @@ public class LichessUser
     public bool? Streaming { get; set; }
 
 
+    public string? Url { get; set; }
+    public string? Playing { get; set; }
     /// <summary>
     ///     Set to true if the user allows being followed
     /// </summary>
     public bool? Followable { get; set; }
 
+    //TODO Add streamer property
+    
     /// <summary>
     ///     Set to true if the user is following
     /// </summary>

--- a/LichessNET/Entities/Social/LichessUser.cs
+++ b/LichessNET/Entities/Social/LichessUser.cs
@@ -71,7 +71,8 @@ public class LichessUser
     /// <summary>
     ///     The total playtime
     /// </summary>
-    public PlaytimeStats? PlayTime { get; set; }
+    [JsonConverter(typeof(SecondsToTimeSpanConverter))]
+    public Playtime PlayTime { get; set; }
 
     /// <summary>
     ///     Title of this user as string

--- a/LichessNET/Entities/Social/UserOverview.cs
+++ b/LichessNET/Entities/Social/UserOverview.cs
@@ -10,14 +10,6 @@ public class UserOverview
     public string Id { get; set; }
     public string Name { get; set; }
     public bool Patron { get; set; }
-    public string Title { get; set; }
 
-    public Title ChessTitle
-    {
-        get
-        {
-            if (string.IsNullOrEmpty(Title)) return Enumerations.Title.None;
-            return (Title)Enum.Parse(typeof(Title), Title, true);
-        }
-    }
+    public Title? Title { get; set; }
 }

--- a/LichessNET/Entities/Stats/GamemodeStats.cs
+++ b/LichessNET/Entities/Stats/GamemodeStats.cs
@@ -1,9 +1,12 @@
-﻿namespace LichessNET.Entities.Stats;
+﻿using System.Text.Json.Serialization;
+using LichessNET.Entities.Interfaces;
+
+namespace LichessNET.Entities.Stats;
 
 /// <summary>
 ///     This class contains all stats of a user in a specific gamemode
 /// </summary>
-public class GamemodeStats
+public class GamemodeStats : IGameStats
 {
     /// <summary>
     ///     Amount of games played in this gamemode
@@ -23,6 +26,7 @@ public class GamemodeStats
     /// <summary>
     ///     The current progress of the user in this gamemode over the last 12 games
     /// </summary>
+    [JsonPropertyName("prog")]
     public int Progress { get; set; }
 
     /// <summary>

--- a/LichessNET/Entities/Stats/Playtime.cs
+++ b/LichessNET/Entities/Stats/Playtime.cs
@@ -1,17 +1,15 @@
 ﻿namespace LichessNET.Entities.Stats;
 
-public class PlaytimeStats
+public class Playtime
 {
-    public int Total;
-    public int Tv;
 
     /// <summary>
     ///     The total time played by the user
     /// </summary>
-    public TimeSpan TotalSpan => TimeSpan.FromSeconds(Total);
+    public TimeSpan TotalSpan { get; set; }
 
     /// <summary>
     ///     The total time seen on TV
     /// </summary>
-    public TimeSpan TvSpan => TimeSpan.FromSeconds(Tv);
+    public TimeSpan TvSpan { get; set; }
 }

--- a/LichessNET/Entities/Stats/RunStats.cs
+++ b/LichessNET/Entities/Stats/RunStats.cs
@@ -1,0 +1,9 @@
+﻿using LichessNET.Entities.Interfaces;
+
+namespace LichessNET.Entities.Stats;
+
+public class RunStats : IGameStats
+{
+    public int Runs { get; set; }
+    public int Score { get; set; }
+}


### PR DESCRIPTION
- Changed Thread.Sleep() to await Task.Delay() in APIRateLimitController, so thread would not be blocked.
- LichessAPIClient now uses 1 instance of HttpClient, this solves port exhaustion (LichessStream uses another instance yet)
- ApiToken is now set in a diffrent method instead of constructor. Method checks if token is valid, and if it is not it throws UnauthorizedAccessException. It makes it easier for developers to set keys and be sure that they work.
- SendRequest method throws exceptions if HttpStatusCode is Forbidden or Unauthorized, same reason.
- Added methods to delete and test API tokens.
- Changed LichessUser model, CreatedAt and SeenAt fields are DateTime instead of string, Title field is now nullable enum, deserialization should work and can deserialize LichessUser correctly, all fields have content API sends (only streaming field is missing), GetOwnProfile and GetUserProfile now work.
- All fields in LichessProfile are nullable now, it makes more sense.
- SendRequest method did not set HttpMethod to request, all requests were sent with HttpMethod.Get, this is why SetKidMode() did not work. 
- Some minor changes: added more gamemodes, removed "None" from Title enum (If user does not have title, field is null), replaced responce.Content.ReadAsStringAsync() with responce.Content.ReadFromJsonAsync() (Though it means we use System.Json instead of Newtonsoft)
