### PR TITLE
Making logging optional

### DIFF
--- a/LichessNET/API/LichessStream.cs
+++ b/LichessNET/API/LichessStream.cs
@@ -91,13 +91,10 @@ public class LichessStream
                         var json = JObject.Parse(line);
                         // Raise the event when a game update is received
                         GameUpdateReceived?.Invoke(this, json);
-                        Console.WriteLine(line);
                     }
                 }
             }
         }
-
-        Console.WriteLine("Exiting Lichess Stream");
         LichessStreamCounter--;
     }
 }


### PR DESCRIPTION
This PR will introduce an optional parameter that will switch off logging for default API requests, but not for Lichess Streams or Database downloads.

It should basically be said that all Loggers are accessing the Setting MinLogLevel, which should be set to Critical or similiar to reduce logging to only critical error loggings.

This closes #18 